### PR TITLE
Manually set is-svg 4.2.2 as dependency on postcss on yarn.lockto pac…

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5852,7 +5852,7 @@ postcss-svgo@^4.0.2:
   resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-4.0.2.tgz#17b997bc711b333bab143aaed3b8d3d6e3d38258"
   integrity sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==
   dependencies:
-    is-svg "^3.0.0"
+    is-svg "^4.2.2"
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
     svgo "^1.0.0"


### PR DESCRIPTION
…kege.json file to fix Dependantbot alerts